### PR TITLE
Reorganize src and test folder structure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,7 @@
   "autoload": {
     "psr-4": {
       "Opulence\\Net\\": "src"
-    },
-    "exclude-from-classmap": [
-      "**/Tests/"
-    ]
+    }
   },
   "require": {
     "ext-mbstring": "*",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,4 +4,12 @@
     <testsuite name="Net">
         <directory>src/Tests</directory>
     </testsuite>
+     <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+            <exclude>
+                <directory suffix=".php">src/Tests</directory>
+            </exclude>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
# Changed log
- Move `src/Tests` to `tests` folder. It can separate the `tests` from `src` folder.
- Add the `autoload-dev` block in `composer.json` to define the test classes autoload.
- Add the white filter tag in `phpunit.xml` to define the code coverage lists.