### PR TITLE
Using data provider and expect exception message

### DIFF
--- a/src/Tests/Formatting/UriParserTest.php
+++ b/src/Tests/Formatting/UriParserTest.php
@@ -12,11 +12,12 @@ namespace Opulence\Net\Tests\Formatting;
 
 use Opulence\Net\Formatting\UriParser;
 use Opulence\Net\Uri;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the URI parser
  */
-class UriParserTest extends \PHPUnit\Framework\TestCase
+class UriParserTest extends TestCase
 {
     /** @var UriParser The URI parser to use in tests */
     private $parser;

--- a/src/Tests/Http/ContentNegotiation/ContentNegotiationResultTest.php
+++ b/src/Tests/Http/ContentNegotiation/ContentNegotiationResultTest.php
@@ -12,11 +12,12 @@ namespace Opulence\Net\Tests\Http\Formatting;
 
 use Opulence\Net\Http\ContentNegotiation\ContentNegotiationResult;
 use Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\IMediaTypeFormatter;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the content negotiation result
  */
-class ContentNegotiationResultTest extends \PHPUnit\Framework\TestCase
+class ContentNegotiationResultTest extends TestCase
 {
     public function testGettingEncodingReturnsSameOneInConstructor(): void
     {

--- a/src/Tests/Http/ContentNegotiation/ContentNegotiatorTest.php
+++ b/src/Tests/Http/ContentNegotiation/ContentNegotiatorTest.php
@@ -16,11 +16,12 @@ use Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\IMediaTypeFormatter
 use Opulence\Net\Http\HttpHeaders;
 use Opulence\Net\Http\IHttpRequestMessage;
 use Opulence\Net\Tests\Http\Formatting\Mocks\User;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the content negotiator
  */
-class ContentNegotiatorTest extends \PHPUnit\Framework\TestCase
+class ContentNegotiatorTest extends TestCase
 {
     /** @var IHttpRequestMessage|\PHPUnit_Framework_MockObject_MockObject The request message to use in tests */
     private $request;
@@ -39,12 +40,14 @@ class ContentNegotiatorTest extends \PHPUnit\Framework\TestCase
     public function testEmptyListOfFormattersThrowsExceptionWhenNegotiatingRequest(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('List of formatters cannot be empty');
         new ContentNegotiator([], []);
     }
 
     public function testEmptyListOfFormattersThrowsExceptionWhenNegotiatingResponse(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('List of formatters cannot be empty');
         new ContentNegotiator([], []);
     }
 

--- a/src/Tests/Http/ContentNegotiation/EncodingMatcherTest.php
+++ b/src/Tests/Http/ContentNegotiation/EncodingMatcherTest.php
@@ -17,11 +17,12 @@ use Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\IMediaTypeFormatter
 use Opulence\Net\Http\Headers\AcceptCharsetHeaderValue;
 use Opulence\Net\Http\Headers\AcceptMediaTypeHeaderValue;
 use Opulence\Net\Http\Headers\ContentTypeHeaderValue;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the encoding matcher
  */
-class EncodingMatcherTest extends \PHPUnit\Framework\TestCase
+class EncodingMatcherTest extends TestCase
 {
     /** @var EncodingMatcher The matcher to use in tests */
     private $matcher;

--- a/src/Tests/Http/ContentNegotiation/LanguageMatcherTest.php
+++ b/src/Tests/Http/ContentNegotiation/LanguageMatcherTest.php
@@ -14,11 +14,12 @@ use Opulence\Collections\ImmutableHashTable;
 use Opulence\Collections\KeyValuePair;
 use Opulence\Net\Http\ContentNegotiation\LanguageMatcher;
 use Opulence\Net\Http\Headers\AcceptLanguageHeaderValue;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the language matcher
  */
-class LanguageMatcherTest extends \PHPUnit\Framework\TestCase
+class LanguageMatcherTest extends TestCase
 {
     /** @var LanguageMatcher The language matcher to use in tests */
     private $matcher;

--- a/src/Tests/Http/ContentNegotiation/MediaTypeFormatterMatchTest.php
+++ b/src/Tests/Http/ContentNegotiation/MediaTypeFormatterMatchTest.php
@@ -13,11 +13,12 @@ namespace Opulence\Net\Tests\Http\Formatting;
 use Opulence\Net\Http\ContentNegotiation\MediaTypeFormatterMatch;
 use Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\IMediaTypeFormatter;
 use Opulence\Net\Http\Headers\ContentTypeHeaderValue;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the media type formatter match result
  */
-class MediaTypeFormatterMatchTest extends \PHPUnit\Framework\TestCase
+class MediaTypeFormatterMatchTest extends TestCase
 {
     public function testGettingFormatterReturnsSameOneInConstructor(): void
     {

--- a/src/Tests/Http/ContentNegotiation/MediaTypeFormatterMatcherTest.php
+++ b/src/Tests/Http/ContentNegotiation/MediaTypeFormatterMatcherTest.php
@@ -18,11 +18,12 @@ use Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\IMediaTypeFormatter
 use Opulence\Net\Http\Headers\AcceptMediaTypeHeaderValue;
 use Opulence\Net\Http\Headers\ContentTypeHeaderValue;
 use Opulence\Net\Tests\Http\Formatting\Mocks\User;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the media type formatter matcher
  */
-class MediaTypeFormatterMatcherTest extends \PHPUnit\Framework\TestCase
+class MediaTypeFormatterMatcherTest extends TestCase
 {
     /** @var MediaTypeFormatterMatcher The matcher to use in tests */
     private $matcher;

--- a/src/Tests/Http/ContentNegotiation/MediaTypeFormatters/FormUrlEncodedMediaTypeFormatterTest.php
+++ b/src/Tests/Http/ContentNegotiation/MediaTypeFormatters/FormUrlEncodedMediaTypeFormatterTest.php
@@ -15,11 +15,12 @@ use Opulence\IO\Streams\IStream;
 use Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\FormUrlEncodedSerializerMediaTypeFormatter;
 use Opulence\Net\Tests\Http\Formatting\Mocks\User;
 use Opulence\Serialization\FormUrlEncodedSerializer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the form URL-encoded media type formatter
  */
-class FormUrlEncodedMediaTypeFormatterTest extends \PHPUnit\Framework\TestCase
+class FormUrlEncodedMediaTypeFormatterTest extends TestCase
 {
     /** @var FormUrlEncodedSerializerMediaTypeFormatter The formatter to use in tests */
     private $formatter;
@@ -79,6 +80,7 @@ class FormUrlEncodedMediaTypeFormatterTest extends \PHPUnit\Framework\TestCase
     public function testReadingTypeThatCannotBeReadThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\FormUrlEncodedSerializerMediaTypeFormatter cannot read type string');
         $stream = $this->createMock(IStream::class);
         $this->formatter->readFromStream($stream, 'string');
     }
@@ -111,12 +113,14 @@ class FormUrlEncodedMediaTypeFormatterTest extends \PHPUnit\Framework\TestCase
     public function testWritingTypeThatCannotBeWrittenThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\FormUrlEncodedSerializerMediaTypeFormatter cannot write type string');
         $this->formatter->writeToStream('foo', $this->createMock(IStream::class), null);
     }
 
     public function testWritingUsingUnsupportedEncodingThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo is not supported for Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\FormUrlEncodedSerializerMediaTypeFormatter');
         $user = new User(123, 'foo@bar.com');
         $this->formatter->writeToStream($user, $this->createMock(IStream::class), 'foo');
     }

--- a/src/Tests/Http/ContentNegotiation/MediaTypeFormatters/FormUrlEncodedMediaTypeFormatterTest.php
+++ b/src/Tests/Http/ContentNegotiation/MediaTypeFormatters/FormUrlEncodedMediaTypeFormatterTest.php
@@ -80,7 +80,7 @@ class FormUrlEncodedMediaTypeFormatterTest extends TestCase
     public function testReadingTypeThatCannotBeReadThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\FormUrlEncodedSerializerMediaTypeFormatter cannot read type string');
+        $this->expectExceptionMessage(sprintf('% s cannot read type string', FormUrlEncodedSerializerMediaTypeFormatter::class));
         $stream = $this->createMock(IStream::class);
         $this->formatter->readFromStream($stream, 'string');
     }
@@ -113,14 +113,14 @@ class FormUrlEncodedMediaTypeFormatterTest extends TestCase
     public function testWritingTypeThatCannotBeWrittenThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\FormUrlEncodedSerializerMediaTypeFormatter cannot write type string');
+        $this->expectExceptionMessage(sprintf('%s cannot write type string', FormUrlEncodedSerializerMediaTypeFormatter::class));
         $this->formatter->writeToStream('foo', $this->createMock(IStream::class), null);
     }
 
     public function testWritingUsingUnsupportedEncodingThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('foo is not supported for Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\FormUrlEncodedSerializerMediaTypeFormatter');
+        $this->expectExceptionMessage(sprintf('foo is not supported for %s', FormUrlEncodedSerializerMediaTypeFormatter::class));
         $user = new User(123, 'foo@bar.com');
         $this->formatter->writeToStream($user, $this->createMock(IStream::class), 'foo');
     }

--- a/src/Tests/Http/ContentNegotiation/MediaTypeFormatters/HtmlMediaTypeFormatterTest.php
+++ b/src/Tests/Http/ContentNegotiation/MediaTypeFormatters/HtmlMediaTypeFormatterTest.php
@@ -14,11 +14,12 @@ use InvalidArgumentException;
 use Opulence\IO\Streams\IStream;
 use Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\HtmlMediaTypeFormatter;
 use Opulence\Net\Tests\Http\Formatting\Mocks\User;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the HTML media type formatter
  */
-class HtmlMediaTypeFormatterTest extends \PHPUnit\Framework\TestCase
+class HtmlMediaTypeFormatterTest extends TestCase
 {
     /** @var HtmlMediaTypeFormatter The formatter to use in tests */
     private $formatter;
@@ -63,6 +64,7 @@ class HtmlMediaTypeFormatterTest extends \PHPUnit\Framework\TestCase
     public function testReadingAsArrayOfStringsThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\HtmlMediaTypeFormatter can only read strings');
         $this->formatter->readFromStream($this->createMock(IStream::class), 'string[]');
     }
 
@@ -76,12 +78,14 @@ class HtmlMediaTypeFormatterTest extends \PHPUnit\Framework\TestCase
     public function testReadingNonStringThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\HtmlMediaTypeFormatter can only read strings');
         $this->formatter->readFromStream($this->createMock(IStream::class), self::class);
     }
 
     public function testReadingTypeThatCannotBeReadThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\HtmlMediaTypeFormatter can only read strings');
         $stream = $this->createMock(IStream::class);
         $this->formatter->readFromStream($stream, User::class);
     }
@@ -99,6 +103,7 @@ class HtmlMediaTypeFormatterTest extends \PHPUnit\Framework\TestCase
     public function testWritingNonStringThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\HtmlMediaTypeFormatter can only write strings');
         $this->formatter->writeToStream($this, $this->createMock(IStream::class), 'utf-8');
     }
 
@@ -111,12 +116,14 @@ class HtmlMediaTypeFormatterTest extends \PHPUnit\Framework\TestCase
     public function testWritingTypeThatCannotBeWrittenThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\HtmlMediaTypeFormatter can only write strings');
         $this->formatter->writeToStream(new User(123, 'foo@bar.com'), $this->createMock(IStream::class), null);
     }
 
     public function testWritingUsingUnsupportedEncodingThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('bar is not supported for Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\HtmlMediaTypeFormatter');
         $this->formatter->writeToStream('foo', $this->createMock(IStream::class), 'bar');
     }
 

--- a/src/Tests/Http/ContentNegotiation/MediaTypeFormatters/HtmlMediaTypeFormatterTest.php
+++ b/src/Tests/Http/ContentNegotiation/MediaTypeFormatters/HtmlMediaTypeFormatterTest.php
@@ -64,7 +64,7 @@ class HtmlMediaTypeFormatterTest extends TestCase
     public function testReadingAsArrayOfStringsThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\HtmlMediaTypeFormatter can only read strings');
+        $this->expectExceptionMessage(sprintf('%s can only read strings', HtmlMediaTypeFormatter::class));
         $this->formatter->readFromStream($this->createMock(IStream::class), 'string[]');
     }
 
@@ -78,14 +78,14 @@ class HtmlMediaTypeFormatterTest extends TestCase
     public function testReadingNonStringThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\HtmlMediaTypeFormatter can only read strings');
+        $this->expectExceptionMessage(sprintf('%s can only read strings', HtmlMediaTypeFormatter::class));
         $this->formatter->readFromStream($this->createMock(IStream::class), self::class);
     }
 
     public function testReadingTypeThatCannotBeReadThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\HtmlMediaTypeFormatter can only read strings');
+        $this->expectExceptionMessage(sprintf('%s can only read strings', HtmlMediaTypeFormatter::class));
         $stream = $this->createMock(IStream::class);
         $this->formatter->readFromStream($stream, User::class);
     }
@@ -116,14 +116,14 @@ class HtmlMediaTypeFormatterTest extends TestCase
     public function testWritingTypeThatCannotBeWrittenThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\HtmlMediaTypeFormatter can only write strings');
+        $this->expectExceptionMessage(sprintf('%s can only write strings', HtmlMediaTypeFormatter::class));
         $this->formatter->writeToStream(new User(123, 'foo@bar.com'), $this->createMock(IStream::class), null);
     }
 
     public function testWritingUsingUnsupportedEncodingThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('bar is not supported for Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\HtmlMediaTypeFormatter');
+        $this->expectExceptionMessage(sprintf('bar is not supported for %s', HtmlMediaTypeFormatter::class));
         $this->formatter->writeToStream('foo', $this->createMock(IStream::class), 'bar');
     }
 

--- a/src/Tests/Http/ContentNegotiation/MediaTypeFormatters/JsonMediaTypeFormatterTest.php
+++ b/src/Tests/Http/ContentNegotiation/MediaTypeFormatters/JsonMediaTypeFormatterTest.php
@@ -88,7 +88,7 @@ class JsonMediaTypeFormatterTest extends TestCase
     public function testWritingUsingUnsupportedEncodingThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('foo is not supported for Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\JsonMediaTypeFormatter');
+        $this->expectExceptionMessage(sprintf('foo is not supported for %s', JsonMediaTypeFormatter::class));
         $user = new User(123, 'foo@bar.com');
         $this->formatter->writeToStream($user, $this->createMock(IStream::class), 'foo');
     }

--- a/src/Tests/Http/ContentNegotiation/MediaTypeFormatters/JsonMediaTypeFormatterTest.php
+++ b/src/Tests/Http/ContentNegotiation/MediaTypeFormatters/JsonMediaTypeFormatterTest.php
@@ -15,11 +15,12 @@ use Opulence\IO\Streams\IStream;
 use Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\JsonMediaTypeFormatter;
 use Opulence\Net\Tests\Http\Formatting\Mocks\User;
 use Opulence\Serialization\JsonSerializer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the JSON media type formatter
  */
-class JsonMediaTypeFormatterTest extends \PHPUnit\Framework\TestCase
+class JsonMediaTypeFormatterTest extends TestCase
 {
     /** @var JsonMediaTypeFormatter The formatter to use in tests */
     private $formatter;
@@ -87,6 +88,7 @@ class JsonMediaTypeFormatterTest extends \PHPUnit\Framework\TestCase
     public function testWritingUsingUnsupportedEncodingThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo is not supported for Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\JsonMediaTypeFormatter');
         $user = new User(123, 'foo@bar.com');
         $this->formatter->writeToStream($user, $this->createMock(IStream::class), 'foo');
     }

--- a/src/Tests/Http/ContentNegotiation/MediaTypeFormatters/PlainTextMediaTypeFormatterTest.php
+++ b/src/Tests/Http/ContentNegotiation/MediaTypeFormatters/PlainTextMediaTypeFormatterTest.php
@@ -14,11 +14,12 @@ use InvalidArgumentException;
 use Opulence\IO\Streams\IStream;
 use Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\PlainTextMediaTypeFormatter;
 use Opulence\Net\Tests\Http\Formatting\Mocks\User;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the plain text media type formatter
  */
-class PlainTextMediaTypeFormatterTest extends \PHPUnit\Framework\TestCase
+class PlainTextMediaTypeFormatterTest extends TestCase
 {
     /** @var PlainTextMediaTypeFormatter The formatter to use in tests */
     private $formatter;
@@ -63,6 +64,7 @@ class PlainTextMediaTypeFormatterTest extends \PHPUnit\Framework\TestCase
     public function testReadingAsArrayOfStringsThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\PlainTextMediaTypeFormatter can only read strings');
         $this->formatter->readFromStream($this->createMock(IStream::class), 'string[]');
     }
 
@@ -76,12 +78,14 @@ class PlainTextMediaTypeFormatterTest extends \PHPUnit\Framework\TestCase
     public function testReadingNonStringThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\PlainTextMediaTypeFormatter can only read strings');
         $this->formatter->readFromStream($this->createMock(IStream::class), self::class);
     }
 
     public function testReadingTypeThatCannotBeReadThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\PlainTextMediaTypeFormatter can only read strings');
         $stream = $this->createMock(IStream::class);
         $this->formatter->readFromStream($stream, User::class);
     }
@@ -89,6 +93,7 @@ class PlainTextMediaTypeFormatterTest extends \PHPUnit\Framework\TestCase
     public function testWritingNonStringThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\PlainTextMediaTypeFormatter can only write strings');
         $this->formatter->writeToStream($this, $this->createMock(IStream::class), 'utf-8');
     }
 
@@ -101,12 +106,14 @@ class PlainTextMediaTypeFormatterTest extends \PHPUnit\Framework\TestCase
     public function testWritingTypeThatCannotBeWrittenThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\PlainTextMediaTypeFormatter can only write strings');
         $this->formatter->writeToStream(new User(123, 'foo@bar.com'), $this->createMock(IStream::class), null);
     }
 
     public function testWritingUsingUnsupportedEncodingThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\PlainTextMediaTypeFormatter');
         $this->formatter->writeToStream('foo', $this->createMock(IStream::class), 'bar');
     }
 

--- a/src/Tests/Http/ContentNegotiation/MediaTypeFormatters/PlainTextMediaTypeFormatterTest.php
+++ b/src/Tests/Http/ContentNegotiation/MediaTypeFormatters/PlainTextMediaTypeFormatterTest.php
@@ -64,7 +64,7 @@ class PlainTextMediaTypeFormatterTest extends TestCase
     public function testReadingAsArrayOfStringsThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\PlainTextMediaTypeFormatter can only read strings');
+        $this->expectExceptionMessage(sprintf('%s can only read strings', PlainTextMediaTypeFormatter::class));
         $this->formatter->readFromStream($this->createMock(IStream::class), 'string[]');
     }
 
@@ -78,14 +78,14 @@ class PlainTextMediaTypeFormatterTest extends TestCase
     public function testReadingNonStringThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\PlainTextMediaTypeFormatter can only read strings');
+        $this->expectExceptionMessage(sprintf('%s can only read strings', PlainTextMediaTypeFormatter::class));
         $this->formatter->readFromStream($this->createMock(IStream::class), self::class);
     }
 
     public function testReadingTypeThatCannotBeReadThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\PlainTextMediaTypeFormatter can only read strings');
+        $this->expectExceptionMessage(sprintf('%s can only read strings', PlainTextMediaTypeFormatter::class));
         $stream = $this->createMock(IStream::class);
         $this->formatter->readFromStream($stream, User::class);
     }
@@ -93,7 +93,7 @@ class PlainTextMediaTypeFormatterTest extends TestCase
     public function testWritingNonStringThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\PlainTextMediaTypeFormatter can only write strings');
+        $this->expectExceptionMessage(sprintf('%s can only write strings', PlainTextMediaTypeFormatter::class));
         $this->formatter->writeToStream($this, $this->createMock(IStream::class), 'utf-8');
     }
 
@@ -106,14 +106,14 @@ class PlainTextMediaTypeFormatterTest extends TestCase
     public function testWritingTypeThatCannotBeWrittenThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\PlainTextMediaTypeFormatter can only write strings');
+        $this->expectExceptionMessage(sprintf('%s can only write strings', PlainTextMediaTypeFormatter::class));
         $this->formatter->writeToStream(new User(123, 'foo@bar.com'), $this->createMock(IStream::class), null);
     }
 
     public function testWritingUsingUnsupportedEncodingThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Opulence\Net\Http\ContentNegotiation\MediaTypeFormatters\PlainTextMediaTypeFormatter');
+        $this->expectExceptionMessage(PlainTextMediaTypeFormatter::class);
         $this->formatter->writeToStream('foo', $this->createMock(IStream::class), 'bar');
     }
 

--- a/src/Tests/Http/ContentNegotiation/NegotiatedResponseFactoryTest.php
+++ b/src/Tests/Http/ContentNegotiation/NegotiatedResponseFactoryTest.php
@@ -228,8 +228,7 @@ class NegotiatedResponseFactoryTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function testCreatingResponseWithObjectBodyWritesToResponseBodyUsingMediaTypeFormatterAndMatchedEncoding(
-    ): void
+    public function testCreatingResponseWithObjectBodyWritesToResponseBodyUsingMediaTypeFormatterAndMatchedEncoding(): void
     {
         $rawBody = new User(123, 'foo@bar.com');
         $responseMediaTypeFormatter = $this->createMock(IMediaTypeFormatter::class);

--- a/src/Tests/Http/CookieTest.php
+++ b/src/Tests/Http/CookieTest.php
@@ -13,11 +13,12 @@ namespace Opulence\Net\Tests\Http;
 use DateTime;
 use InvalidArgumentException;
 use Opulence\Net\Http\Cookie;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests cookies
  */
-class CookieTest extends \PHPUnit\Framework\TestCase
+class CookieTest extends TestCase
 {
     /** @var Cookie The cookie to use in tests */
     private $cookie;
@@ -128,6 +129,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
     public function testInvalidNameThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cookie name "=" contains invalid characters');
         $this->cookie->setName('=');
     }
 
@@ -142,6 +144,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
     public function testSettingInvalidExpirationValueThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expiration must be integer or DateTime');
         new Cookie('foo', 'bar', 'baz');
     }
 

--- a/src/Tests/Http/Formatting/HttpBodyParserTest.php
+++ b/src/Tests/Http/Formatting/HttpBodyParserTest.php
@@ -10,15 +10,16 @@
 
 namespace Opulence\Net\Tests\Http\Formatting;
 
+use RuntimeException;
 use Opulence\Collections\HashTable;
 use Opulence\Net\Http\Formatting\HttpBodyParser;
 use Opulence\Net\Http\IHttpBody;
-use RuntimeException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the HTTP body parser
  */
-class HttpBodyParserTest extends \PHPUnit\Framework\TestCase
+class HttpBodyParserTest extends TestCase
 {
     /** @var HttpBodyParser The parser to use in tests */
     private $parser;
@@ -76,6 +77,7 @@ class HttpBodyParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingJsonWithIncorrectlyFormattedJsonThrowsException(): void
     {
         $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Body could not be decoded as JSON');
         $this->body->expects($this->once())
             ->method('readAsString')
             ->willReturn("\x0");

--- a/src/Tests/Http/Formatting/HttpHeaderParserTest.php
+++ b/src/Tests/Http/Formatting/HttpHeaderParserTest.php
@@ -13,11 +13,12 @@ namespace Opulence\Net\Tests\Http\Formatting;
 use Opulence\Collections\ImmutableHashTable;
 use Opulence\Net\Http\Formatting\HttpHeaderParser;
 use Opulence\Net\Http\HttpHeaders;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the HTTP header parser
  */
-class HttpHeaderParserTest extends \PHPUnit\Framework\TestCase
+class HttpHeaderParserTest extends TestCase
 {
     /** @var HttpHeaderParser The parser to use in tests */
     private $parser = null;

--- a/src/Tests/Http/Formatting/RequestHeaderParserTest.php
+++ b/src/Tests/Http/Formatting/RequestHeaderParserTest.php
@@ -12,11 +12,12 @@ namespace Opulence\Net\Tests\Http\Formatting;
 
 use Opulence\Net\Http\Formatting\RequestHeaderParser;
 use Opulence\Net\Http\HttpHeaders;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the request header parser
  */
-class RequestHeaderParserTest extends \PHPUnit\Framework\TestCase
+class RequestHeaderParserTest extends TestCase
 {
     /** @var RequestHeaderParser The parser to use in tests */
     private $parser;

--- a/src/Tests/Http/Formatting/RequestParserTest.php
+++ b/src/Tests/Http/Formatting/RequestParserTest.php
@@ -17,11 +17,12 @@ use Opulence\Net\Http\Formatting\RequestParser;
 use Opulence\Net\Http\HttpHeaders;
 use Opulence\Net\Http\IHttpBody;
 use Opulence\Net\Http\IHttpRequestMessage;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the HTTP request message parser
  */
-class RequestParserTest extends \PHPUnit\Framework\TestCase
+class RequestParserTest extends TestCase
 {
     /** @var RequestParser The parser to use in tests */
     private $parser;
@@ -66,12 +67,14 @@ class RequestParserTest extends \PHPUnit\Framework\TestCase
     public function testGettingMimeTypeOfNonRequestNorMultipartBodyPartThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Request must be of type Opulence\Net\Http\IHttpRequestMessage or Opulence\Net\Http\MultipartBodyPart');
         $this->parser->getMimeType([]);
     }
 
     public function testParsingMultipartRequestWithoutBoundaryThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"boundary" is missing in Content-Type header');
         $this->headers->add('Content-Type', 'multipart/mixed');
         $this->parser->readAsMultipart($this->request);
     }
@@ -79,6 +82,7 @@ class RequestParserTest extends \PHPUnit\Framework\TestCase
     public function testParsingNonRequestNorMultipartBodyPartThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Request must be of type Opulence\Net\Http\IHttpRequestMessage or Opulence\Net\Http\MultipartBodyPart');
         $this->parser->readAsMultipart([]);
     }
 }

--- a/src/Tests/Http/Formatting/RequestParserTest.php
+++ b/src/Tests/Http/Formatting/RequestParserTest.php
@@ -16,6 +16,7 @@ use Opulence\Collections\IDictionary;
 use Opulence\Net\Http\Formatting\RequestParser;
 use Opulence\Net\Http\HttpHeaders;
 use Opulence\Net\Http\IHttpBody;
+use Opulence\Net\Http\MultipartBodyPart;
 use Opulence\Net\Http\IHttpRequestMessage;
 use PHPUnit\Framework\TestCase;
 
@@ -67,7 +68,7 @@ class RequestParserTest extends TestCase
     public function testGettingMimeTypeOfNonRequestNorMultipartBodyPartThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Request must be of type Opulence\Net\Http\IHttpRequestMessage or Opulence\Net\Http\MultipartBodyPart');
+        $this->expectExceptionMessage(sprintf('Request must be of type %s or %s', IHttpRequestMessage::class, MultipartBodyPart::class));
         $this->parser->getMimeType([]);
     }
 
@@ -82,7 +83,7 @@ class RequestParserTest extends TestCase
     public function testParsingNonRequestNorMultipartBodyPartThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Request must be of type Opulence\Net\Http\IHttpRequestMessage or Opulence\Net\Http\MultipartBodyPart');
+        $this->expectExceptionMessage(sprintf('Request must be of type %s or %s', IHttpRequestMessage::class, MultipartBodyPart::class));
         $this->parser->readAsMultipart([]);
     }
 }

--- a/src/Tests/Http/Formatting/ResponseFormatterTest.php
+++ b/src/Tests/Http/Formatting/ResponseFormatterTest.php
@@ -72,7 +72,7 @@ class ResponseFormatterTest extends TestCase
     public function testRedirectingToUriThatIsNotUriNorStringThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Uri must be instance of Opulence\Net\Uri or string');
+        $this->expectExceptionMessage(sprintf('Uri must be instance of %s or string', Uri::class));
         $this->formatter->redirectToUri($this->response, [], 301);
     }
 }

--- a/src/Tests/Http/Formatting/ResponseFormatterTest.php
+++ b/src/Tests/Http/Formatting/ResponseFormatterTest.php
@@ -16,11 +16,12 @@ use Opulence\Net\Http\HttpHeaders;
 use Opulence\Net\Http\IHttpResponseMessage;
 use Opulence\Net\Http\StringBody;
 use Opulence\Net\Uri;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the HTTP response message formatter
  */
-class ResponseFormatterTest extends \PHPUnit\Framework\TestCase
+class ResponseFormatterTest extends TestCase
 {
     /** @var ResponseFormatter The formatter to use in tests */
     private $formatter;
@@ -71,6 +72,7 @@ class ResponseFormatterTest extends \PHPUnit\Framework\TestCase
     public function testRedirectingToUriThatIsNotUriNorStringThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Uri must be instance of Opulence\Net\Uri or string');
         $this->formatter->redirectToUri($this->response, [], 301);
     }
 }

--- a/src/Tests/Http/Formatting/ResponseHeaderFormatterTest.php
+++ b/src/Tests/Http/Formatting/ResponseHeaderFormatterTest.php
@@ -14,11 +14,12 @@ use DateTime;
 use Opulence\Net\Http\Cookie;
 use Opulence\Net\Http\Formatting\ResponseHeaderFormatter;
 use Opulence\Net\Http\HttpHeaders;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the HTTP response header formatter
  */
-class ResponseHeaderFormatterTest extends \PHPUnit\Framework\TestCase
+class ResponseHeaderFormatterTest extends TestCase
 {
     /** @var ResponseHeaderFormatter The formatter to use in tests */
     private $formatter;

--- a/src/Tests/Http/Headers/AcceptCharsetHeaderValueTest.php
+++ b/src/Tests/Http/Headers/AcceptCharsetHeaderValueTest.php
@@ -15,29 +15,30 @@ use Opulence\Collections\IImmutableDictionary;
 use Opulence\Collections\ImmutableHashTable;
 use Opulence\Collections\KeyValuePair;
 use Opulence\Net\Http\Headers\AcceptCharsetHeaderValue;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the Accept-Charset header value
  */
-class AcceptCharsetHeaderValueTest extends \PHPUnit\Framework\TestCase
+class AcceptCharsetHeaderValueTest extends TestCase
 {
-    public function testExceptionThrownWithQualityScoreOutsideAcceptedRange(): void
+    public function qualityScoreOutsideAcceptedRangeProvider(): array
     {
-        try {
-            $parameters = new ImmutableHashTable([new KeyValuePair('q', '-1')]);
-            new AcceptCharsetHeaderValue('utf-8', $parameters);
-            $this->fail('Failed to throw exception for quality score less than 0');
-        } catch (InvalidArgumentException $ex) {
-            $this->assertTrue(true);
-        }
+        return [
+            ['-1'],
+            ['1.5'],
+        ];
+    }
 
-        try {
-            $parameters = new ImmutableHashTable([new KeyValuePair('q', '1.5')]);
-            new AcceptCharsetHeaderValue('utf-8', $parameters);
-            $this->fail('Failed to throw exception for quality score greater than 1');
-        } catch (InvalidArgumentException $ex) {
-            $this->assertTrue(true);
-        }
+    /**
+     * @dataProvider qualityScoreOutsideAcceptedRangeProvider
+     */
+    public function testExceptionThrownWithQualityScoreOutsideAcceptedRange($invalidScore): void
+    {
+        $parameters = new ImmutableHashTable([new KeyValuePair('q', $invalidScore)]);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Quality score must be between 0 and 1, inclusive');
+        new AcceptCharsetHeaderValue('utf-8', $parameters);
     }
 
     public function testGettingCharsetReturnsSameOneSetInConstructor(): void

--- a/src/Tests/Http/Headers/AcceptLanguageHeaderValueTest.php
+++ b/src/Tests/Http/Headers/AcceptLanguageHeaderValueTest.php
@@ -15,29 +15,30 @@ use Opulence\Collections\IImmutableDictionary;
 use Opulence\Collections\ImmutableHashTable;
 use Opulence\Collections\KeyValuePair;
 use Opulence\Net\Http\Headers\AcceptLanguageHeaderValue;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the Accept-Language header value
  */
-class AcceptLanguageHeaderValueTest extends \PHPUnit\Framework\TestCase
+class AcceptLanguageHeaderValueTest extends TestCase
 {
-    public function testExceptionThrownWithQualityScoreOutsideAcceptedRange(): void
+    public function qualityScoreOutsideAcceptedRangeProvider(): array
     {
-        try {
-            $parameters = new ImmutableHashTable([new KeyValuePair('q', '-1')]);
-            new AcceptLanguageHeaderValue('en-US', $parameters);
-            $this->fail('Failed to throw exception for quality score less than 0');
-        } catch (InvalidArgumentException $ex) {
-            $this->assertTrue(true);
-        }
+        return [
+            ['-1'],
+            ['1.5'],
+        ];
+    }
 
-        try {
-            $parameters = new ImmutableHashTable([new KeyValuePair('q', '1.5')]);
-            new AcceptLanguageHeaderValue('en-US', $parameters);
-            $this->fail('Failed to throw exception for quality score greater than 1');
-        } catch (InvalidArgumentException $ex) {
-            $this->assertTrue(true);
-        }
+    /**
+     * @dataProvider qualityScoreOutsideAcceptedRangeProvider
+     */
+    public function testExceptionThrownWithQualityScoreOutsideAcceptedRange($invalidScore): void
+    {
+        $parameters = new ImmutableHashTable([new KeyValuePair('q', $invalidScore)]);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Quality score must be between 0 and 1, inclusive');
+        new AcceptLanguageHeaderValue('en-US', $parameters);
     }
 
     public function testGettingLanguageReturnsSameOneSetInConstructor(): void

--- a/src/Tests/Http/Headers/AcceptMediaTypeHeaderValueTest.php
+++ b/src/Tests/Http/Headers/AcceptMediaTypeHeaderValueTest.php
@@ -14,29 +14,30 @@ use InvalidArgumentException;
 use Opulence\Collections\ImmutableHashTable;
 use Opulence\Collections\KeyValuePair;
 use Opulence\Net\Http\Headers\AcceptMediaTypeHeaderValue;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the Accept media type header value
  */
-class AcceptMediaTypeHeaderValueTest extends \PHPUnit\Framework\TestCase
+class AcceptMediaTypeHeaderValueTest extends TestCase
 {
-    public function testExceptionThrownWithQualityScoreOutsideAcceptedRange(): void
+    public function qualityScoreOutsideAcceptedRangeProvider(): array
     {
-        try {
-            $parameters = new ImmutableHashTable([new KeyValuePair('q', '-1')]);
-            new AcceptMediaTypeHeaderValue('foo/bar', $parameters);
-            $this->fail('Failed to throw exception for quality score less than 0');
-        } catch (InvalidArgumentException $ex) {
-            $this->assertTrue(true);
-        }
+        return [
+            ['-1'],
+            ['1.5'],
+        ];
+    }
 
-        try {
-            $parameters = new ImmutableHashTable([new KeyValuePair('q', '1.5')]);
-            new AcceptMediaTypeHeaderValue('foo/bar', $parameters);
-            $this->fail('Failed to throw exception for quality score greater than 1');
-        } catch (InvalidArgumentException $ex) {
-            $this->assertTrue(true);
-        }
+    /**
+     * @dataProvider qualityScoreOutsideAcceptedRangeProvider
+     */
+    public function testExceptionThrownWithQualityScoreOutsideAcceptedRange($invalidScore): void
+    {
+        $parameters = new ImmutableHashTable([new KeyValuePair('q', $invalidScore)]);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Quality score must be between 0 and 1, inclusive');
+        new AcceptMediaTypeHeaderValue('foo/bar', $parameters);
     }
 
     public function testGettingQualityReturnsCorrectQuality(): void

--- a/src/Tests/Http/Headers/ContentTypeHeaderValueTest.php
+++ b/src/Tests/Http/Headers/ContentTypeHeaderValueTest.php
@@ -15,11 +15,12 @@ use Opulence\Collections\IImmutableDictionary;
 use Opulence\Collections\ImmutableHashTable;
 use Opulence\Collections\KeyValuePair;
 use Opulence\Net\Http\Headers\ContentTypeHeaderValue;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the Content-Type header value
  */
-class ContentTypeHeaderValueTest extends \PHPUnit\Framework\TestCase
+class ContentTypeHeaderValueTest extends TestCase
 {
     public function testGettingCharsetReturnsOneSetInConstructor(): void
     {
@@ -47,27 +48,21 @@ class ContentTypeHeaderValueTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('foo', $value->getType());
     }
 
-    public function testIncorrectlyFormattedMediaTypeThrowsException(): void
+    public function incorrectlyFormattedMediaTypeProvider(): array
     {
-        try {
-            new ContentTypeHeaderValue('foo', $this->createMock(IImmutableDictionary::class));
-            $this->fail('"foo" is in invalid media type');
-        } catch (InvalidArgumentException $ex) {
-            $this->assertTrue(true);
-        }
+        return [
+            ['foo'],
+            ['foo/'],
+        ];
+    }
 
-        try {
-            new ContentTypeHeaderValue('foo/', $this->createMock(IImmutableDictionary::class));
-            $this->fail('"foo/" is in invalid media type');
-        } catch (InvalidArgumentException $ex) {
-            $this->assertTrue(true);
-        }
-
-        try {
-            new ContentTypeHeaderValue('/foo', $this->createMock(IImmutableDictionary::class));
-            $this->fail('"/foo" is in invalid media type');
-        } catch (InvalidArgumentException $ex) {
-            $this->assertTrue(true);
-        }
+    /**
+     * @dataProvider incorrectlyFormattedMediaTypeProvider
+     */
+    public function testIncorrectlyFormattedMediaTypeThrowsException($incorrectlyFormattedMediaType): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Media type must be in format {type}/{sub-type}, received {$incorrectlyFormattedMediaType}");
+        new ContentTypeHeaderValue($incorrectlyFormattedMediaType, $this->createMock(IImmutableDictionary::class));
     }
 }

--- a/src/Tests/Http/Headers/MediaTypeHeaderValueTest.php
+++ b/src/Tests/Http/Headers/MediaTypeHeaderValueTest.php
@@ -15,11 +15,12 @@ use Opulence\Collections\IImmutableDictionary;
 use Opulence\Collections\ImmutableHashTable;
 use Opulence\Collections\KeyValuePair;
 use Opulence\Net\Http\Headers\MediaTypeHeaderValue;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the media type header value
  */
-class MediaTypeHeaderValueTest extends \PHPUnit\Framework\TestCase
+class MediaTypeHeaderValueTest extends TestCase
 {
     public function testGettingCharsetReturnsOneSetInConstructor(): void
     {
@@ -47,27 +48,22 @@ class MediaTypeHeaderValueTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('foo', $value->getType());
     }
 
-    public function testIncorrectlyFormattedMediaTypeThrowsException(): void
+    public function incorrectlyFormattedMediaTypeProvider(): array
     {
-        try {
-            new MediaTypeHeaderValue('foo', $this->createMock(IImmutableDictionary::class));
-            $this->fail('"foo" is in invalid media type');
-        } catch (InvalidArgumentException $ex) {
-            $this->assertTrue(true);
-        }
+        return [
+            ['foo'],
+            ['foo/'],
+            ['/foo'],
+        ];
+    }
 
-        try {
-            new MediaTypeHeaderValue('foo/', $this->createMock(IImmutableDictionary::class));
-            $this->fail('"foo/" is in invalid media type');
-        } catch (InvalidArgumentException $ex) {
-            $this->assertTrue(true);
-        }
-
-        try {
-            new MediaTypeHeaderValue('/foo', $this->createMock(IImmutableDictionary::class));
-            $this->fail('"/foo" is in invalid media type');
-        } catch (InvalidArgumentException $ex) {
-            $this->assertTrue(true);
-        }
+    /**
+     * @dataProvider incorrectlyFormattedMediaTypeProvider
+     */
+    public function testIncorrectlyFormattedMediaTypeThrowsException($incorrectlyFormattedMediaType): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Media type must be in format {type}/{sub-type}, received {$incorrectlyFormattedMediaType}");
+        new MediaTypeHeaderValue($incorrectlyFormattedMediaType, $this->createMock(IImmutableDictionary::class));
     }
 }

--- a/src/Tests/Http/HttpExceptionTest.php
+++ b/src/Tests/Http/HttpExceptionTest.php
@@ -14,11 +14,12 @@ use Exception;
 use InvalidArgumentException;
 use Opulence\Net\Http\HttpException;
 use Opulence\Net\Http\IHttpResponseMessage;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the HTTP exception
  */
-class HttpExceptionTest extends \PHPUnit\Framework\TestCase
+class HttpExceptionTest extends TestCase
 {
     public function testCodeIsSameOneSetInConstructor(): void
     {
@@ -29,6 +30,7 @@ class HttpExceptionTest extends \PHPUnit\Framework\TestCase
     public function testInvalidStatusCodeOrResponseThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('First parameter must be either a status code or an HTTP response');
         new HttpException('foo');
     }
 

--- a/src/Tests/Http/HttpHeadersTest.php
+++ b/src/Tests/Http/HttpHeadersTest.php
@@ -177,7 +177,7 @@ class HttpHeadersTest extends TestCase
     public function testAddRangeOnInvalidValue(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Value must be instance of Opulence\Collections\KeyValuePair');
+        $this->expectExceptionMessage(sprintf('Value must be instance of %s', KeyValuePair::class));
         $this->headers->addRange(['invalid KeyValuePair']);
     }
 }

--- a/src/Tests/Http/HttpHeadersTest.php
+++ b/src/Tests/Http/HttpHeadersTest.php
@@ -10,15 +10,16 @@
 
 namespace Opulence\Net\Tests\Http;
 
-use Opulence\Collections\KeyValuePair;
-use Opulence\Net\Http\HttpHeaders;
 use OutOfBoundsException;
 use InvalidArgumentException;
+use Opulence\Collections\KeyValuePair;
+use Opulence\Net\Http\HttpHeaders;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the HTTP headers
  */
-class HttpHeadersTest extends \PHPUnit\Framework\TestCase
+class HttpHeadersTest extends TestCase
 {
     /** @var HttpHeaders The headers to use */
     private $headers;
@@ -56,6 +57,7 @@ class HttpHeadersTest extends \PHPUnit\Framework\TestCase
     public function testGettingFirstValueWhenKeyDoesNotExistThrowsException(): void
     {
         $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage('Header "foo" does not exist');
         $this->headers->getFirst('foo');
     }
 
@@ -153,7 +155,7 @@ class HttpHeadersTest extends \PHPUnit\Framework\TestCase
          */
         foreach ($this->headers->toArray() as $key => $value) {
             // Verify that the key is numeric, not associative
-            $this->assertTrue(\is_int($key));
+            $this->assertInternalType('integer', $key);
             $this->assertInstanceOf(KeyValuePair::class, $value);
             $actualValues[$value->getKey()] = $value->getValue();
         }
@@ -175,6 +177,7 @@ class HttpHeadersTest extends \PHPUnit\Framework\TestCase
     public function testAddRangeOnInvalidValue(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Value must be instance of Opulence\Collections\KeyValuePair');
         $this->headers->addRange(['invalid KeyValuePair']);
     }
 }

--- a/src/Tests/Http/HttpStatusCodesTest.php
+++ b/src/Tests/Http/HttpStatusCodesTest.php
@@ -11,11 +11,12 @@
 namespace Opulence\Net\Tests\Http;
 
 use Opulence\Net\Http\HttpStatusCodes;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the HTTP status codes
  */
-class HttpStatusCodesTest extends \PHPUnit\Framework\TestCase
+class HttpStatusCodesTest extends TestCase
 {
     public function testExistingStatusCodeReturnsDefaultStatusText(): void
     {

--- a/src/Tests/Http/MultipartBodyPartTest.php
+++ b/src/Tests/Http/MultipartBodyPartTest.php
@@ -13,11 +13,12 @@ namespace Opulence\Net\Tests\Http;
 use Opulence\Net\Http\HttpHeaders;
 use Opulence\Net\Http\IHttpBody;
 use Opulence\Net\Http\MultipartBodyPart;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the multipart body part
  */
-class MultipartBodyPartTest extends \PHPUnit\Framework\TestCase
+class MultipartBodyPartTest extends TestCase
 {
     /** @var MultipartBodyPart The body part to use in tests */
     private $bodyPart;

--- a/src/Tests/Http/MultipartBodyTest.php
+++ b/src/Tests/Http/MultipartBodyTest.php
@@ -17,11 +17,12 @@ use Opulence\Net\Http\IHttpBody;
 use Opulence\Net\Http\MultipartBody;
 use Opulence\Net\Http\MultipartBodyPart;
 use Opulence\Net\Http\StringBody;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the multipart body
  */
-class MultipartBodyTest extends \PHPUnit\Framework\TestCase
+class MultipartBodyTest extends TestCase
 {
     public function testGettingBoundaryReturnsBoundarySpecifiedInConstructor(): void
     {

--- a/src/Tests/Http/ResponseTest.php
+++ b/src/Tests/Http/ResponseTest.php
@@ -14,11 +14,12 @@ use Opulence\Net\Http\HttpHeaders;
 use Opulence\Net\Http\HttpStatusCodes;
 use Opulence\Net\Http\IHttpBody;
 use Opulence\Net\Http\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the response class
  */
-class ResponseTest extends \PHPUnit\Framework\TestCase
+class ResponseTest extends TestCase
 {
     public function testDefaultReasonPhraseIsSet(): void
     {

--- a/src/Tests/Http/ResponseWriterTest.php
+++ b/src/Tests/Http/ResponseWriterTest.php
@@ -15,11 +15,12 @@ use Opulence\Net\Http\HttpHeaders;
 use Opulence\Net\Http\IHttpBody;
 use Opulence\Net\Http\IHttpResponseMessage;
 use Opulence\Net\Http\ResponseWriter;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the response writer
  */
-class ResponseWriterTest extends \PHPUnit\Framework\TestCase
+class ResponseWriterTest extends TestCase
 {
     /** @var ResponseWriter The response writer to use in tests */
     private $writer;

--- a/src/Tests/Http/StreamBodyTest.php
+++ b/src/Tests/Http/StreamBodyTest.php
@@ -12,11 +12,12 @@ namespace Opulence\Net\Tests\Http;
 
 use Opulence\IO\Streams\IStream;
 use Opulence\Net\Http\StreamBody;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the stream body
  */
-class StreamBodyTest extends \PHPUnit\Framework\TestCase
+class StreamBodyTest extends TestCase
 {
     public function testCastingToStringConvertsUnderlyingStreamToString(): void
     {

--- a/src/Tests/Http/StringBodyTest.php
+++ b/src/Tests/Http/StringBodyTest.php
@@ -12,11 +12,12 @@ namespace Opulence\Net\Tests\Http;
 
 use Opulence\IO\Streams\IStream;
 use Opulence\Net\Http\StringBody;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the string body
  */
-class StringBodyTest extends \PHPUnit\Framework\TestCase
+class StringBodyTest extends TestCase
 {
     public function testCastingToStringReturnsContents(): void
     {


### PR DESCRIPTION
# Changed log

- Using `use PHPUnit\Framework\TestCase` namespace style because of consistency.
- Using `data provider` to collect test cases and split this from assertion methods.
- Using the `expectExceptionMessage` to check whether the expected exception message is same as actual exception message.
- Using the `assertInternalType` to assert whether the expected type is `integer`.